### PR TITLE
GH workflows now work with branch 'develop'

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,7 @@
 on:
   push:
     branches:
+      - develop
       - main
       - master
   pull_request:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:
+      - develop
       - main
       - master
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:
+      - develop
       - main
       - master
   pull_request:


### PR DESCRIPTION
This PR update relevant gh-actions workflows so they are
triggered by actions on the new branch 'develop'.
﻿
