### PR TITLE
Fix website reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -39,8 +39,8 @@ reference:
 
   - title: Plot
     contents:
-      - matches("plot_.*X")
-      - theme_2dii
+      - starts_with("plot_")
+      - starts_with("theme_")
 
   - title: Datasets
     contents:


### PR DESCRIPTION
This PR fixes the website's reference to remove duplicated references to the datasets. Not sure why.

It is a fix and touches no production code so I'll merge with no further review.