### PR TITLE
Rename to emission intensity

### DIFF
--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -1,4 +1,4 @@
-#' Create a timeline plot
+#' Create an emission intensity plot
 #'
 #' @param data A data frame. Requirements:
 #'   * The structure must be like [sda].
@@ -33,7 +33,7 @@ plot_emission_intensity <- function(data, extrapolate = FALSE) {
     abort_if_too_many_lines() %>%
     add_r2dii_colours()
 
-  plot_timeline_impl(prep, specs = specs)
+  plot_emission_intensity_impl(prep, specs = specs)
 }
 
 prep_emission_intensity <- function(data,
@@ -72,7 +72,7 @@ prep_emission_intensity <- function(data,
   out
 }
 
-plot_timeline_impl <- function(data, specs) {
+plot_emission_intensity_impl <- function(data, specs) {
   data <- left_join(data, specs, by = "line_name")
 
   ggplot() +

--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -27,7 +27,7 @@ plot_emission_intensity <- function(data, extrapolate = FALSE) {
   data <- data %>%
     mutate(emission_factor_metric = to_title(.data$emission_factor_metric))
 
-  prep <- hint_if_missing_names(prep_timeline(data, extrapolate = extrapolate))
+  prep <- hint_if_missing_names(prep_emission_intensity(data, extrapolate = extrapolate))
   line_names <- unique(prep$line_name)
   specs <- tibble(line_name = line_names, label = line_names) %>%
     abort_if_too_many_lines() %>%
@@ -36,7 +36,7 @@ plot_emission_intensity <- function(data, extrapolate = FALSE) {
   plot_timeline_impl(prep, specs = specs)
 }
 
-prep_timeline <- function(data,
+prep_emission_intensity <- function(data,
                           value = "emission_factor_value",
                           metric = "emission_factor_metric",
                           extrapolate = FALSE) {

--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -37,9 +37,9 @@ plot_emission_intensity <- function(data, extrapolate = FALSE) {
 }
 
 prep_emission_intensity <- function(data,
-                          value = "emission_factor_value",
-                          metric = "emission_factor_metric",
-                          extrapolate = FALSE) {
+                                    value = "emission_factor_value",
+                                    metric = "emission_factor_metric",
+                                    extrapolate = FALSE) {
   data <- filter_to_metric_start_year(data, metric)
 
   out <- data %>%

--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -215,8 +215,7 @@ get_ordered_scenario_specs <- function(data) {
     pull(.data$green_or_brown) %>%
     unique()
 
-  switch(
-    technology_kind,
+  switch(technology_kind,
     "green" = reverse_rows(tibble(
       scenario = c(ordered_scenarios, c("worse")),
       colour = scenario_colours$hex

--- a/R/utils.R
+++ b/R/utils.R
@@ -232,7 +232,9 @@ get_common_start_year <- function(data, metric) {
 
 filter_to_metric_start_year <- function(data, metric) {
   start_year <- get_common_start_year(data, metric)
-  if (!min(data$year) < start_year) return(data)
+  if (!min(data$year) < start_year) {
+    return(data)
+  }
 
   if (!quiet()) inform(glue("Excluding data before start year of 'projected'."))
   filter(data, .data$year >= start_year)

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,7 +86,7 @@ abort_if_has_zero_rows <- function(data) {
 hint_if_missing_names <- function(expr) {
   .expr <- deparse_1(substitute(expr))
   fun <- format_plot_function_name(.expr)
-  kind <- ifelse(grepl("timeline", fun), "sda", "market_share")
+  kind <- ifelse(grepl("emission_intensity", fun), "sda", "market_share")
 
   rlang::with_handlers(
     expr,

--- a/man/plot_emission_intensity.Rd
+++ b/man/plot_emission_intensity.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/plot_emission_intensity.R
 \name{plot_emission_intensity}
 \alias{plot_emission_intensity}
-\title{Create a timeline plot}
+\title{Create an emission intensity plot}
 \usage{
 plot_emission_intensity(data, extrapolate = FALSE)
 }
@@ -20,7 +20,7 @@ furthest value in the data set.}
 An object of class "ggplot".
 }
 \description{
-Create a timeline plot
+Create an emission intensity plot
 }
 \examples{
 # `data` must meet documented "Requirements"


### PR DESCRIPTION
This relates to a previous issue. Somehow some "timeline"
strings survived. This PR changes them to "emission
intensity".

This is well agreed and internal so I'll merge with no
further review.


