### PR TITLE
In internal code use dplyr::filter() not subset()

### DIFF
--- a/tests/testthat/test-plot_techmix.R
+++ b/tests/testthat/test-plot_techmix.R
@@ -67,14 +67,14 @@ test_that("with missing crucial names errors gracefully", {
 
 test_that("with input data before start year of 'projected' prep_techmix
           outputs data with start year of 'projected'", {
-  data <- subset(
+  data <- filter(
     market_share,
-    sector == "power" &
-      region == "global" &
-      year <= 2025 &
+    sector == "power",
+      region == "global",
+      year <= 2025,
       metric %in% c("projected", "corporate_economy", "target_sds")
   )
-  start_year <- min(subset(data, metric == "projected")$year)
+  start_year <- min(filter(data, metric == "projected")$year)
   early_row <- tibble(
     sector = "power",
     technology = "renewablescap",

--- a/tests/testthat/test-plot_trajectory.R
+++ b/tests/testthat/test-plot_trajectory.R
@@ -100,12 +100,12 @@ test_that("with too many scenarios errors gracefully", {
     }
     data
   }
-  data <- subset(
+  data <- filter(
     market_share,
-    sector == "power" &
-      region == "global" &
-      technology == "renewablescap" &
-      year <= 2025
+    sector == "power",
+    region == "global",
+    technology == "renewablescap",
+    year <= 2025
   ) %>%
     add_fake_scenarios_market_share(5)
 
@@ -155,27 +155,15 @@ test_that("outputs pretty labels", {
   expect_true(has_pretty_format)
 })
 
-test_that("works with example data", {
-  data <- subset(
-    market_share,
-    sector == "power" &
-      region == "global" &
-      technology == "renewablescap" &
-      year <= 2025
-  )
-
-  expect_no_error(plot_trajectory(data))
-})
-
 test_that("works with input data starting before start year of 'projected'", {
-  data <- subset(
+  data <- filter(
     market_share,
-    sector == "power" &
-      region == "global" &
-      technology == "renewablescap" &
-      year <= 2025
+    sector == "power",
+    region == "global",
+    technology == "renewablescap",
+    year <= 2025
   )
-  start_year <- min(subset(data, metric == "projected")$year)
+  start_year <- min(filter(data, metric == "projected")$year)
   to_exclude <- tibble(
     sector = "power",
     technology = "renewablescap",
@@ -207,7 +195,7 @@ test_that("informs excluding data before start year of 'projected'", {
     technology == "renewablescap",
     year <= 2025
   )
-  start_year <- min(subset(data, metric == "projected")$year)
+  start_year <- min(filter(data, metric == "projected")$year)
   to_exclude <- tibble(
     sector = "power",
     technology = "renewablescap",


### PR DESCRIPTION
?subset:
> Warning
> This is a convenience function intended for use interactively.
> For programming it is better to use the standard subsetting
> functions like [, and in particular the non-standard evaluation
> of argument subset can have unanticipated consequences.

dplyr::filter() also uses non-standard evaluation but is safe to
program with thanks to the tidy eval framework.
