### PR TITLE
New integration test for sda

### DIFF
--- a/tests/testthat/test-plot_techmix.R
+++ b/tests/testthat/test-plot_techmix.R
@@ -70,9 +70,9 @@ test_that("with input data before start year of 'projected' prep_techmix
   data <- filter(
     market_share,
     sector == "power",
-      region == "global",
-      year <= 2025,
-      metric %in% c("projected", "corporate_economy", "target_sds")
+    region == "global",
+    year <= 2025,
+    metric %in% c("projected", "corporate_economy", "target_sds")
   )
   start_year <- min(filter(data, metric == "projected")$year)
   early_row <- tibble(

--- a/tests/testthat/test-sda.R
+++ b/tests/testthat/test-sda.R
@@ -6,3 +6,28 @@ test_that("outputs the expected snapshot", {
   skip_if(r_version_is_older_than(4))
   expect_snapshot(sda)
 })
+
+test_that("outputs like r2dii.analysis::target_sda()", {
+  # This integration (not unit) test checks if this function keeps its promise.
+  # It may overlap with other unit tests, but here we focus on dependencies
+
+  # Such a strong dependency on upstream packages makes this test fragile
+  skip_on_cran()
+
+  sort_df <- function(data) data[sort(names(data))]
+
+  # Pick small data for speed. "package::f()" is to emphasize integration
+  loanbook <- r2dii.data::loanbook_demo[125:150, ]
+  ald <- filter(r2dii.data::ald_demo[1:100, ], !is.na(.data$emission_factor))
+  scenario <- r2dii.data::co2_intensity_scenario_demo
+
+  expected <- r2dii.match::match_name(loanbook, ald) %>%
+    r2dii.match::prioritize() %>%
+    r2dii.analysis::target_sda(ald, co2_intensity_scenario = scenario) %>%
+    sort_df() %>%
+    vapply(typeof, character(1))
+  actual <- sda %>%
+    sort_df() %>%
+    vapply(typeof, character(1))
+  expect_equal(actual, expected)
+})


### PR DESCRIPTION
- New integration test for sda

We had one for market_share but not sda. The idea is to
automatically check that the helpifle of sda keeps its
promise, i.e. that sda has the structure as the output
of r2dii.analysis::target_sda().

