### PR TITLE
Polish documentation

### DIFF
--- a/R/market_share.R
+++ b/R/market_share.R
@@ -1,4 +1,6 @@
-#' Dataset imitating the output of `r2dii.analysis::target_market_share()`
+#' An example of a `market_share`-like dataset
+#'
+#' Dataset imitating the output of [r2dii.analysis::target_market_share()].
 #'
 #' @seealso [r2dii.analysis::target_market_share()].
 #' @family datasets

--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -62,7 +62,7 @@ plot_emission_intensity_impl <- function(data, specs) {
     scale_y_continuous(expand = expansion(mult = c(0, 0.1))) +
     scale_colour_manual(values = unique(data$hex)) +
     scale_linetype_manual(values = "solid") +
-    guides(linetype = FALSE) +
+    guides(linetype = "none") +
     theme_2dii()
 }
 

--- a/R/sda.R
+++ b/R/sda.R
@@ -1,7 +1,6 @@
-#' Dataset imitating the output of `r2dii.analysis::target_sda()`
+#' An example of an `sda`-like dataset
 #'
-#' Example data set of emission factors for different metric types: projected,
-#' benchmark and scenarios and different sectors.
+#' Dataset imitating the output of [r2dii.analysis::target_sda()].
 #'
 #' @seealso [r2dii.analysis::target_sda()].
 #' @family datasets

--- a/R/theme_2dii.R
+++ b/R/theme_2dii.R
@@ -1,4 +1,4 @@
-#' A theme to apply 2DII plotting aesthetics
+#' Complete theme
 #'
 #' A ggplot theme which can be applied to all graphs to appear according to 2DII
 #' plotting aesthetics.
@@ -9,15 +9,15 @@
 #'
 #' @return An object of class `r toString(class(theme_2dii()))`.
 #'
+#' @seealso [ggplot2::theme_classic].
+#'
 #' @export
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
 #'
-#' p <- ggplot(mtcars) +
-#'   geom_histogram(aes(mpg), bins = 10)
-#' p
-#'
-#' p + theme_2dii()
+#' ggplot(mtcars) +
+#'   geom_histogram(aes(mpg), bins = 10) +
+#'   theme_2dii()
 theme_2dii <- function(base_size = 12,
                        base_family = "Helvetica",
                        base_line_size = base_size / 22,

--- a/man/market_share.Rd
+++ b/man/market_share.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{market_share}
 \alias{market_share}
-\title{Dataset imitating the output of \code{r2dii.analysis::target_market_share()}}
+\title{An example of a \code{market_share}-like dataset}
 \format{
 An object of class \code{spec_tbl_df} (inherits from \code{tbl_df}, \code{tbl}, \code{data.frame}) with 1170 rows and 8 columns.
 }
@@ -11,7 +11,7 @@ An object of class \code{spec_tbl_df} (inherits from \code{tbl_df}, \code{tbl}, 
 market_share
 }
 \description{
-Dataset imitating the output of \code{r2dii.analysis::target_market_share()}
+Dataset imitating the output of \code{\link[r2dii.analysis:target_market_share]{r2dii.analysis::target_market_share()}}.
 }
 \examples{
 market_share

--- a/man/sda.Rd
+++ b/man/sda.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{sda}
 \alias{sda}
-\title{Dataset imitating the output of \code{r2dii.analysis::target_sda()}}
+\title{An example of an \code{sda}-like dataset}
 \format{
 An object of class \code{spec_tbl_df} (inherits from \code{tbl_df}, \code{tbl}, \code{data.frame}) with 208 rows and 4 columns.
 }
@@ -14,8 +14,7 @@ An object of class \code{spec_tbl_df} (inherits from \code{tbl_df}, \code{tbl}, 
 sda
 }
 \description{
-Example data set of emission factors for different metric types: projected,
-benchmark and scenarios and different sectors.
+Dataset imitating the output of \code{\link[r2dii.analysis:target_sda]{r2dii.analysis::target_sda()}}.
 }
 \examples{
 sda

--- a/man/theme_2dii.Rd
+++ b/man/theme_2dii.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/theme_2dii.R
 \name{theme_2dii}
 \alias{theme_2dii}
-\title{A theme to apply 2DII plotting aesthetics}
+\title{Complete theme}
 \usage{
 theme_2dii(
   base_size = 12,
@@ -30,10 +30,11 @@ plotting aesthetics.
 \examples{
 library(ggplot2, warn.conflicts = FALSE)
 
-p <- ggplot(mtcars) +
-  geom_histogram(aes(mpg), bins = 10)
-p
-
-p + theme_2dii()
+ggplot(mtcars) +
+  geom_histogram(aes(mpg), bins = 10) +
+  theme_2dii()
+}
+\seealso{
+\link[ggplot2:ggtheme]{ggplot2::theme_classic}.
 }
 \concept{plotting functions}


### PR DESCRIPTION
Also avoid this:

    #> Warning: `guides(<scale> = FALSE)` is deprecated. Please use `guides(<scale> = "none")` instead.
