### PR TITLE
Do generate internal helpfile for r2dii_colours

### DIFF
--- a/R/r2dii_colours.R
+++ b/R/r2dii_colours.R
@@ -18,7 +18,6 @@
 #' r2dii.plot:::sector_colours
 #'
 #' r2dii.plot:::technology_colours
-#' @noRd
 NULL
 
 #' @rdname r2dii_colours


### PR DESCRIPTION
In the first release we removed internal documentation to minimize
the chances that CRAN would find some problem with it. This PR
restores that internal documentation that should be hidden from the
public website but available at */reference/r2dii.colours.html﻿
