### PR TITLE
Modify annotation space

### DIFF
--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -104,19 +104,30 @@ plot_trajectory_impl <- function(data) {
   )
 
   lines_end <- filter(order_trajectory(data), .data$year == max(data$year))
-  issue_346 <- 6
+  year_span <- max(data$year) - min(data$year)
   p <- p + ggrepel::geom_text_repel(
     data = lines_end,
-    aes(label = .data$label, segment.color = .data$metric),
+    aes(
+      y = .data$value,
+      label = .data$label,
+      segment.color = .data$metric),
     direction = "y",
     color = "black",
     size = 3.5,
     alpha = 1,
-    nudge_x = if_else(is_scenario(lines_end$metric), 0.6, 0.1),
-    nudge_y = 0.01 * value_span(data),
+    nudge_x = if_else(
+      is_scenario(lines_end$metric),
+      0.06 * year_span,
+      0.01 * year_span
+      ),
+    nudge_y = if_else(
+      is_scenario(lines_end$metric),
+      0.01 * value_span(data),
+      0
+      ),
     hjust = 0,
     segment.size = if_else(is_scenario(lines_end$metric), 0.4, 0),
-    xlim = c(min(data$year), max(data$year) + issue_346)
+    xlim = c(min(data$year), max(data$year) + 0.7 * year_span)
   )
 
   p +

--- a/R/qplot_trajectory.R
+++ b/R/qplot_trajectory.R
@@ -49,7 +49,8 @@ labs_trajectory <- function(p) {
   p +
     labs(
       title = glue(
-        "Production Trajectory of Technology: {tech} in the {sector} Sector"
+        "Production Trajectory of Technology: {tech}
+        in the {sector} Sector"
       ),
       subtitle = glue(
         "The coloured areas indicate trajectories in reference to a scenario.

--- a/tests/testthat/_snaps/qplot_trajectory.md
+++ b/tests/testthat/_snaps/qplot_trajectory.md
@@ -57,7 +57,8 @@
 
 # Wraps the title as expected
 
-    Production Trajectory of Technology: Electric in the Automotive Sector
+    Production Trajectory of Technology: Electric
+    in the Automotive Sector
 
 # Wraps the subtitle as expected
 


### PR DESCRIPTION
Closes #347 

In this PR I make the space left for annotations data-dependent instead of hardcoded 6 years. 

Minor change: wrap the trajectory title.