### PR TITLE
Use a list as an environment for substitute()

### DIFF
--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -15,9 +15,9 @@
 #' data <- subset(sda, sector == "cement")
 #' plot_emission_intensity(data)
 plot_emission_intensity <- function(data) {
-  env <- list(data = substitute(data))
+  check_plot_emission_intensity(data, env = list(data = substitute(data)))
 
-  prep <- prep_emission_intensity(data, env = env)
+  prep <- prep_emission_intensity(data)
   plot_emission_intensity_impl(prep)
 }
 
@@ -35,9 +35,7 @@ check_plot_emission_intensity <- function(data, env) {
 
 prep_emission_intensity <- function(data,
                                     convert_label = identity,
-                                    span_5yr = FALSE,
-                                    env = NULL) {
-  check_plot_emission_intensity(data, env)
+                                    span_5yr = FALSE) {
   out <- data %>%
     prep_common() %>%
     mutate(label = convert_label(.data$label))

--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -15,13 +15,13 @@
 #' data <- subset(sda, sector == "cement")
 #' plot_emission_intensity(data)
 plot_emission_intensity <- function(data) {
-  check_plot_emission_intensity(data)
+  env <- list(data = substitute(data))
 
-  prep <- prep_emission_intensity(data)
+  prep <- prep_emission_intensity(data, env = env)
   plot_emission_intensity_impl(prep)
 }
 
-check_plot_emission_intensity <- function(data, env = parent.frame()) {
+check_plot_emission_intensity <- function(data, env) {
   stopifnot(is.data.frame(data))
   crucial <- c("sector", "year", glue("emission_factor_{c('metric', 'value')}"))
   hint_if_missing_names(abort_if_missing_names(data, crucial), "sda")
@@ -33,7 +33,11 @@ check_plot_emission_intensity <- function(data, env = parent.frame()) {
   invisible(data)
 }
 
-prep_emission_intensity <- function(data, convert_label = identity, span_5yr = FALSE) {
+prep_emission_intensity <- function(data,
+                                    convert_label = identity,
+                                    span_5yr = FALSE,
+                                    env = NULL) {
+  check_plot_emission_intensity(data, env)
   out <- data %>%
     prep_common() %>%
     mutate(label = convert_label(.data$label))

--- a/R/plot_techmix.R
+++ b/R/plot_techmix.R
@@ -27,13 +27,11 @@
 #'
 #' plot_techmix(data)
 plot_techmix <- function(data) {
-  check_plot_techmix(data)
-
-  prep <- prep_techmix(data)
+  prep <- prep_techmix(data, env = list(data = substitute(data)))
   plot_techmix_impl(prep)
 }
 
-check_plot_techmix <- function(data, env = parent.frame()) {
+check_plot_techmix <- function(data, env) {
   stopifnot(is.data.frame(data))
   crucial <- c(common_crucial_market_share_columns(), "technology_share")
   hint_if_missing_names(abort_if_missing_names(data, crucial), "market_share")
@@ -76,7 +74,10 @@ abort_if_multiple_scenarios <- function(data, env = parent.frame()) {
 prep_techmix <- function(data,
                          convert_label = identity,
                          span_5yr = FALSE,
-                         convert_tech_label = identity) {
+                         convert_tech_label = identity,
+                         env = NULL) {
+  check_plot_techmix(data, env = env)
+
   out <- data %>%
     prep_common() %>%
     add_label_tech_if_missing() %>%

--- a/R/plot_techmix.R
+++ b/R/plot_techmix.R
@@ -27,9 +27,10 @@
 #'
 #' plot_techmix(data)
 plot_techmix <- function(data) {
-  check_plot_techmix(data, env = list(data = substitute(data)))
+  env <- list(data = substitute(data))
+  check_plot_techmix(data, env = env)
 
-  prep <- prep_techmix(data)
+  prep <- prep_techmix(data, env = env)
   plot_techmix_impl(prep)
 }
 
@@ -76,7 +77,8 @@ abort_if_multiple_scenarios <- function(data, env = parent.frame()) {
 prep_techmix <- function(data,
                          convert_label = identity,
                          span_5yr = FALSE,
-                         convert_tech_label = identity) {
+                         convert_tech_label = identity,
+                         env = NULL) {
   out <- data %>%
     prep_common() %>%
     add_label_tech_if_missing() %>%
@@ -94,7 +96,7 @@ prep_techmix <- function(data,
   start_year <- min(out$year)
   future_year <- max(out$year)
   if (!quiet()) {
-    .data <- deparse_1(substitute(data, env = parent.frame()))
+    .data <- deparse_1(substitute(data, env = env))
     inform(glue(
       "The `technology_share` values are plotted for extreme years.
        Do you want to plot different years? E.g. filter {.data} with:\\

--- a/R/plot_techmix.R
+++ b/R/plot_techmix.R
@@ -27,7 +27,8 @@
 #'
 #' plot_techmix(data)
 plot_techmix <- function(data) {
-  prep <- prep_techmix(data, env = list(data = substitute(data)))
+  check_plot_techmix(data, env = list(data = substitute(data)))
+  prep <- prep_techmix(data)
   plot_techmix_impl(prep)
 }
 
@@ -74,10 +75,7 @@ abort_if_multiple_scenarios <- function(data, env = parent.frame()) {
 prep_techmix <- function(data,
                          convert_label = identity,
                          span_5yr = FALSE,
-                         convert_tech_label = identity,
-                         env = NULL) {
-  check_plot_techmix(data, env = env)
-
+                         convert_tech_label = identity) {
   out <- data %>%
     prep_common() %>%
     add_label_tech_if_missing() %>%

--- a/R/plot_techmix.R
+++ b/R/plot_techmix.R
@@ -28,6 +28,7 @@
 #' plot_techmix(data)
 plot_techmix <- function(data) {
   check_plot_techmix(data, env = list(data = substitute(data)))
+
   prep <- prep_techmix(data)
   plot_techmix_impl(prep)
 }

--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -23,10 +23,10 @@
 #'
 #' plot_trajectory(data)
 plot_trajectory <- function(data) {
-  env <- list(data = substitute(data))
+  check_plot_trajectory(data, env = list(data = substitute(data)))
 
   data %>%
-    prep_trajectory(convert_label = identity, span_5yr = FALSE, env = env) %>%
+    prep_trajectory(convert_label = identity, span_5yr = FALSE) %>%
     plot_trajectory_impl()
 }
 
@@ -52,10 +52,7 @@ check_plot_trajectory <- function(data, env) {
 #' @noRd
 prep_trajectory <- function(data,
                             convert_label = identity,
-                            span_5yr = FALSE,
-                            env = NULL) {
-  check_plot_trajectory(data, env)
-
+                            span_5yr = FALSE) {
   out <- data %>%
     prep_common() %>%
     mutate(value = .data$production) %>%

--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -13,7 +13,7 @@
 #' @export
 #' @examples
 #' # `data` must meet documented "Requirements"
-#' data <- subset(
+#' mydata <- subset(
 #'   market_share,
 #'   sector == "power" &
 #'     technology == "renewablescap" &
@@ -21,21 +21,16 @@
 #'     scenario_source == "demo_2020"
 #' )
 #'
-#' plot_trajectory(data)
+#' plot_trajectory(mydata)
 plot_trajectory <- function(data) {
-  check_plot_trajectory(data)
+  env <- list(data = substitute(data))
 
   data %>%
-    prep_trajectory(convert_label = identity, span_5yr = FALSE) %>%
+    prep_trajectory(convert_label = identity, span_5yr = FALSE, env = env) %>%
     plot_trajectory_impl()
 }
 
-# The `env` argument supports non-standard evaluation to print informative error
-# messages that mention the symbol passed to `data` (e.g. "my_data") rather than
-# the name of the argument (i.e. `data`). Although tests should warn you,
-# breaking this functionality is easy, for example, by wrapping this function
-# and moving it deeper into the caller stack.
-check_plot_trajectory <- function(data, env = parent.frame()) {
+check_plot_trajectory <- function(data, env) {
   stopifnot(is.data.frame(data))
   crucial <- c(common_crucial_market_share_columns(), "production")
   hint_if_missing_names(abort_if_missing_names(data, crucial), "market_share")
@@ -57,7 +52,10 @@ check_plot_trajectory <- function(data, env = parent.frame()) {
 #' @noRd
 prep_trajectory <- function(data,
                             convert_label = identity,
-                            span_5yr = FALSE) {
+                            span_5yr = FALSE,
+                            env = NULL) {
+  check_plot_trajectory(data, env)
+
   out <- data %>%
     prep_common() %>%
     mutate(value = .data$production) %>%

--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -13,7 +13,7 @@
 #' @export
 #' @examples
 #' # `data` must meet documented "Requirements"
-#' mydata <- subset(
+#' data <- subset(
 #'   market_share,
 #'   sector == "power" &
 #'     technology == "renewablescap" &
@@ -21,7 +21,7 @@
 #'     scenario_source == "demo_2020"
 #' )
 #'
-#' plot_trajectory(mydata)
+#' plot_trajectory(data)
 plot_trajectory <- function(data) {
   env <- list(data = substitute(data))
 
@@ -109,7 +109,8 @@ plot_trajectory_impl <- function(data) {
     aes(
       y = .data$value,
       label = .data$label,
-      segment.color = .data$metric),
+      segment.color = .data$metric
+    ),
     direction = "y",
     color = "black",
     size = 3.5,
@@ -118,12 +119,12 @@ plot_trajectory_impl <- function(data) {
       is_scenario(lines_end$metric),
       0.06 * year_span,
       0.01 * year_span
-      ),
+    ),
     nudge_y = if_else(
       is_scenario(lines_end$metric),
       0.01 * value_span(data),
       0
-      ),
+    ),
     hjust = 0,
     segment.size = if_else(is_scenario(lines_end$metric), 0.4, 0),
     xlim = c(min(data$year), max(data$year) + 0.7 * year_span)

--- a/R/qplot_emission_intensity.R
+++ b/R/qplot_emission_intensity.R
@@ -17,10 +17,12 @@
 #'
 #' qplot_emission_intensity(data)
 qplot_emission_intensity <- function(data) {
-  check_plot_emission_intensity(data)
+  env <- list(data = substitute(data))
 
   data %>%
-    prep_emission_intensity(convert_label = to_title, span_5yr = TRUE) %>%
+    prep_emission_intensity(
+      convert_label = to_title, span_5yr = TRUE, env = env
+    ) %>%
     plot_emission_intensity_impl() %>%
     labs_emission_intensity()
 }

--- a/R/qplot_emission_intensity.R
+++ b/R/qplot_emission_intensity.R
@@ -17,12 +17,10 @@
 #'
 #' qplot_emission_intensity(data)
 qplot_emission_intensity <- function(data) {
-  env <- list(data = substitute(data))
+  check_plot_emission_intensity(data, env = list(data = substitute(data)))
 
   data %>%
-    prep_emission_intensity(
-      convert_label = to_title, span_5yr = TRUE, env = env
-    ) %>%
+    prep_emission_intensity(convert_label = to_title, span_5yr = TRUE) %>%
     plot_emission_intensity_impl() %>%
     labs_emission_intensity()
 }

--- a/R/qplot_techmix.R
+++ b/R/qplot_techmix.R
@@ -23,13 +23,15 @@
 #'
 #' qplot_techmix(data)
 qplot_techmix <- function(data) {
-  check_plot_techmix(data, env = list(data = substitute(data)))
+  env <- list(data = substitute(data))
+  check_plot_techmix(data, env = env)
 
   data %>%
     prep_techmix(
       convert_label = format_label_techmix,
       span_5yr = TRUE,
-      convert_tech_label = spell_out_technology
+      convert_tech_label = spell_out_technology,
+      env = env
     ) %>%
     plot_techmix_impl() %>%
     labs_techmix()

--- a/R/qplot_techmix.R
+++ b/R/qplot_techmix.R
@@ -23,12 +23,13 @@
 #'
 #' qplot_techmix(data)
 qplot_techmix <- function(data) {
+  check_plot_techmix(data, env = list(data = substitute(data)))
+
   data %>%
     prep_techmix(
       convert_label = format_label_techmix,
       span_5yr = TRUE,
-      convert_tech_label = spell_out_technology,
-      env = list(data = substitute(data))
+      convert_tech_label = spell_out_technology
     ) %>%
     plot_techmix_impl() %>%
     labs_techmix()

--- a/R/qplot_techmix.R
+++ b/R/qplot_techmix.R
@@ -23,13 +23,12 @@
 #'
 #' qplot_techmix(data)
 qplot_techmix <- function(data) {
-  check_plot_techmix(data)
-
   data %>%
     prep_techmix(
       convert_label = format_label_techmix,
       span_5yr = TRUE,
-      convert_tech_label = spell_out_technology
+      convert_tech_label = spell_out_technology,
+      env = list(data = substitute(data))
     ) %>%
     plot_techmix_impl() %>%
     labs_techmix()

--- a/R/qplot_trajectory.R
+++ b/R/qplot_trajectory.R
@@ -24,10 +24,10 @@
 #'
 #' qplot_trajectory(data)
 qplot_trajectory <- function(data) {
-  env <- list(data = substitute(data))
+  check_plot_trajectory(data, env = list(data = substitute(data)))
 
   data %>%
-    prep_trajectory(convert_label = format_label, span_5yr = TRUE, env = env) %>%
+    prep_trajectory(convert_label = format_label, span_5yr = TRUE) %>%
     plot_trajectory_impl() %>%
     labs_trajectory()
 }

--- a/R/qplot_trajectory.R
+++ b/R/qplot_trajectory.R
@@ -24,10 +24,10 @@
 #'
 #' qplot_trajectory(data)
 qplot_trajectory <- function(data) {
-  check_plot_trajectory(data)
+  env <- list(data = substitute(data))
 
   data %>%
-    prep_trajectory(convert_label = format_label, span_5yr = TRUE) %>%
+    prep_trajectory(convert_label = format_label, span_5yr = TRUE, env = env) %>%
     plot_trajectory_impl() %>%
     labs_trajectory()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -56,7 +56,7 @@ deparse_1 <- function(expr, collapse = " ", width.cutoff = 500L, ...) {
 }
 
 abort_if_has_zero_rows <- function(data, env) {
-  .data <- deparse_1(substitute(data, env))
+  .data <- deparse_1(substitute(data, env = env))
   if (nrow(data) == 0L) {
     abort(c(
       glue("`{.data}` must have some rows."),

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,8 +55,8 @@ deparse_1 <- function(expr, collapse = " ", width.cutoff = 500L, ...) {
   paste(deparse(expr, width.cutoff, ...), collapse = collapse)
 }
 
-abort_if_has_zero_rows <- function(data, env = parent.frame()) {
-  .data <- deparse_1(substitute(data, env = env))
+abort_if_has_zero_rows <- function(data, env) {
+  .data <- deparse_1(substitute(data, env))
   if (nrow(data) == 0L) {
     abort(c(
       glue("`{.data}` must have some rows."),

--- a/tests/testthat/_snaps/plot_techmix.md
+++ b/tests/testthat/_snaps/plot_techmix.md
@@ -41,8 +41,8 @@
 # informs that extreme years are used
 
     Code
-      invisible(plot_techmix(data))
+      invisible(plot_techmix(mydata))
     Message <message>
       The `technology_share` values are plotted for extreme years.
-      Do you want to plot different years? E.g. filter data with:`subset(data, year %in% c(2020, 2030))`.
+      Do you want to plot different years? E.g. filter mydata with:`subset(mydata, year %in% c(2020, 2030))`.
 

--- a/tests/testthat/test-plot_techmix.R
+++ b/tests/testthat/test-plot_techmix.R
@@ -91,7 +91,7 @@ test_that("with input data before start year of 'projected' prep_techmix
 })
 
 test_that("informs that extreme years are used", {
-  data <- filter(
+  mydata <- filter(
     market_share,
     sector == "power",
     region == "global",
@@ -101,7 +101,7 @@ test_that("informs that extreme years are used", {
 
   restore <- options(r2dii.plot.quiet = FALSE)
   expect_snapshot(invisible(
-    plot_techmix(data)
+    plot_techmix(mydata)
   ))
   options(restore)
 })


### PR DESCRIPTION
Replace `env  = parent.frame()` with `env = list(data = substitute(data))`

This is more flexible: It allows to move the make the final
substitution at any depth in the call stack.

This solves the same main concern than #385 with less changes.
My focus here was to make the diffs as small as possible.

--

Reference: http://adv-r.had.co.nz/Computing-on-the-language.html#substitute