### PR TITLE
Adjust the base_size according to specs

### DIFF
--- a/R/theme_2dii.R
+++ b/R/theme_2dii.R
@@ -26,6 +26,7 @@ theme_2dii <- function(base_size = 12,
   margin <- margin(5, 5, 5, 5)
 
   theme_classic(
+    base_size = base_size,
     base_family = base_family,
     base_line_size = base_line_size,
     base_rect_size = base_rect_size


### PR DESCRIPTION
In this PR I pass the `base_size` argument passed by the user to `theme_classic()` so that all the sizes in the plot are adjusted correctly.

Makes the #384 redundant. 