### PR TITLE
Remove link to r2dii

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,11 +30,6 @@ navbar:
     - icon: fa-github
       href: https://github.com/2DegreesInvesting/r2dii.plot
 
-    - text: r2dii
-      href: https://2degreesinvesting.github.io/r2dii/index.html
-
-
-
 reference:
 
   - title: Plot


### PR DESCRIPTION
The r2dii meta package is poorly maintained so it's likely best
to not point external users to it.
