### PR TITLE
Restore Get started

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,6 +24,9 @@ navbar:
   type: default
 
   left:
+  - text: "Get started"
+    href: articles/r2dii-match.html
+
   - text: "Reference"
     href: reference/index.html
 


### PR DESCRIPTION
The section "Get started" is gone. I must have removed it by
accident. This commit restores it.
