### PR TITLE
Polish documentation

### DIFF
--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -58,7 +58,6 @@ check_plot_trajectory <- function(data, env) {
   invisible(data)
 }
 
-#' @noRd
 prep_trajectory <- function(data,
                             convert_label = identity,
                             span_5yr = FALSE,

--- a/R/scale_r2dii.R
+++ b/R/scale_r2dii.R
@@ -11,6 +11,7 @@
 #' @export
 #'
 #' @aliases scale_color_r2dii
+#' @family r2dii scales
 #'
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
@@ -32,7 +33,6 @@ scale_fill_r2dii <- function(labels = NULL, ...) {
   discrete_scale("fill", "r2dii", r2dii_pal(labels), ...)
 }
 
-#' @noRd
 r2dii_pal <- function(labels = NULL) {
   check_labels(labels)
 

--- a/R/scale_r2dii_sector.R
+++ b/R/scale_r2dii_sector.R
@@ -12,6 +12,7 @@
 #' @export
 #'
 #' @aliases scale_color_r2dii_sector
+#' @family r2dii scales
 #'
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
@@ -33,7 +34,6 @@ scale_fill_r2dii_sector <- function(sectors = NULL, ...) {
   discrete_scale("fill", "r2dii_sector", r2dii_sec_pal(sectors), ...)
 }
 
-#' @noRd
 r2dii_sec_pal <- function(sectors = NULL) {
   check_sectors(sectors)
 

--- a/R/scale_r2dii_tech.R
+++ b/R/scale_r2dii_tech.R
@@ -16,6 +16,7 @@
 #' @export
 #'
 #' @aliases scale_color_r2dii_tech
+#' @family r2dii scales
 #'
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
@@ -37,7 +38,6 @@ scale_fill_r2dii_tech <- function(sector, technologies = NULL, ...) {
   discrete_scale("fill", "r2dii_tech", r2dii_tech_pal(sector, technologies), ...)
 }
 
-#' @noRd
 r2dii_tech_pal <- function(sector, technologies = NULL) {
   check_sector(sector)
   check_technologies(sector, technologies)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -67,7 +67,7 @@ reference:
   - subtitle: Styling functions
     contents:
       - starts_with("theme_")
-      - starts_with("scale_")
+      - has_concept("r2dii scales")
 
   - title: Datasets
     contents:

--- a/man/scale_colour_r2dii.Rd
+++ b/man/scale_colour_r2dii.Rd
@@ -34,3 +34,9 @@ ggplot(data = mpg) +
  geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
  scale_fill_r2dii()
 }
+\seealso{
+Other r2dii scales: 
+\code{\link{scale_colour_r2dii_sector}()},
+\code{\link{scale_colour_r2dii_tech}()}
+}
+\concept{r2dii scales}

--- a/man/scale_colour_r2dii_sector.Rd
+++ b/man/scale_colour_r2dii_sector.Rd
@@ -35,3 +35,9 @@ ggplot(data = mpg) +
  geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
  scale_fill_r2dii_sector()
 }
+\seealso{
+Other r2dii scales: 
+\code{\link{scale_colour_r2dii_tech}()},
+\code{\link{scale_colour_r2dii}()}
+}
+\concept{r2dii scales}

--- a/man/scale_colour_r2dii_tech.Rd
+++ b/man/scale_colour_r2dii_tech.Rd
@@ -40,3 +40,9 @@ ggplot(data = mpg) +
  geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
  scale_fill_r2dii_tech("automotive")
 }
+\seealso{
+Other r2dii scales: 
+\code{\link{scale_colour_r2dii_sector}()},
+\code{\link{scale_colour_r2dii}()}
+}
+\concept{r2dii scales}


### PR DESCRIPTION
* Remove `@noRd` where it's not necessary. This tag stops roxygen2
from creating an R-documentation (.Rd) file, so we use to write
developer-facing documentation that should not result in an .Rd
file (the ones we access with `?functionname`). But if a function
has no documentation at all (most, simple internal functions don't)
then roxygen won't create an .Rd file anyway, so @noRd adds nothing.

* New family 'r2dii scales' generate a link between all `scale_*()`
functions -- i.e. the section "See also". This helps users navigate
the documentation of similar functions. It also helps create the
reference section of the website in a more specific way: i.e. with
`has_concept('name of the family')` instead of
`starts_with('prefix')`.
