### PR TITLE
Remove needless argument names and namespace

### DIFF
--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -98,7 +98,7 @@ prep_trajectory <- function(data,
 }
 
 plot_trajectory_impl <- function(data) {
-  p <- ggplot(order_trajectory(data), aes(x = .data$year, y = .data$value))
+  p <- ggplot(order_trajectory(data), aes(.data$year, .data$value))
 
   scenarios <- data %>% filter(is_scenario(metric))
   p <- p + geom_ribbon(

--- a/R/scale_r2dii.R
+++ b/R/scale_r2dii.R
@@ -15,12 +15,12 @@
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
 #'
-#' ggplot(data = mpg) +
-#'  geom_point(mapping = aes(x = displ, y = hwy, color = class)) +
+#' ggplot(mpg) +
+#'  geom_point(aes(displ, hwy, color = class)) +
 #'  scale_colour_r2dii()
 #'
-#' ggplot(data = mpg) +
-#'  geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
+#' ggplot(mpg) +
+#'  geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
 #'  scale_fill_r2dii()
 scale_colour_r2dii <- function(labels = NULL, ...) {
   discrete_scale("colour", "r2dii", r2dii_pal(labels), ...)

--- a/R/scale_r2dii_sector.R
+++ b/R/scale_r2dii_sector.R
@@ -16,12 +16,12 @@
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
 #'
-#' ggplot(data = mpg) +
-#'  geom_point(mapping = aes(x = displ, y = hwy, color = class)) +
+#' ggplot(mpg) +
+#'  geom_point(aes(displ, hwy, color = class)) +
 #'  scale_colour_r2dii_sector()
 #'
-#'  ggplot(data = mpg) +
-#'  geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
+#'  ggplot(mpg) +
+#'  geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
 #'  scale_fill_r2dii_sector()
 scale_colour_r2dii_sector <- function(sectors = NULL, ...) {
   discrete_scale("colour", "r2dii_sector", r2dii_sec_pal(sectors), ...)

--- a/R/scale_r2dii_tech.R
+++ b/R/scale_r2dii_tech.R
@@ -20,12 +20,12 @@
 #' @examples
 #' library(ggplot2, warn.conflicts = FALSE)
 #'
-#' ggplot(data = mpg) +
-#'  geom_point(mapping = aes(x = displ, y = hwy, color = class)) +
+#' ggplot(mpg) +
+#'  geom_point(aes(displ, hwy, color = class)) +
 #'  scale_colour_r2dii_tech("automotive")
 #'
-#'  ggplot(data = mpg) +
-#'  geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
+#'  ggplot(mpg) +
+#'  geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
 #'  scale_fill_r2dii_tech("automotive")
 scale_colour_r2dii_tech <- function(sector, technologies = NULL, ...) {
   discrete_scale("colour", "r2dii_tech", r2dii_tech_pal(sector, technologies), ...)

--- a/man/scale_colour_r2dii.Rd
+++ b/man/scale_colour_r2dii.Rd
@@ -26,11 +26,11 @@ A custom discrete colour and fill scales with colours from 2DII palette.
 \examples{
 library(ggplot2, warn.conflicts = FALSE)
 
-ggplot(data = mpg) +
- geom_point(mapping = aes(x = displ, y = hwy, color = class)) +
+ggplot(mpg) +
+ geom_point(aes(displ, hwy, color = class)) +
  scale_colour_r2dii()
 
-ggplot(data = mpg) +
- geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
+ggplot(mpg) +
+ geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
  scale_fill_r2dii()
 }

--- a/man/scale_colour_r2dii_sector.Rd
+++ b/man/scale_colour_r2dii_sector.Rd
@@ -27,11 +27,11 @@ palette.
 \examples{
 library(ggplot2, warn.conflicts = FALSE)
 
-ggplot(data = mpg) +
- geom_point(mapping = aes(x = displ, y = hwy, color = class)) +
+ggplot(mpg) +
+ geom_point(aes(displ, hwy, color = class)) +
  scale_colour_r2dii_sector()
 
- ggplot(data = mpg) +
- geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
+ ggplot(mpg) +
+ geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
  scale_fill_r2dii_sector()
 }

--- a/man/scale_colour_r2dii_tech.Rd
+++ b/man/scale_colour_r2dii_tech.Rd
@@ -32,11 +32,11 @@ palette.
 \examples{
 library(ggplot2, warn.conflicts = FALSE)
 
-ggplot(data = mpg) +
- geom_point(mapping = aes(x = displ, y = hwy, color = class)) +
+ggplot(mpg) +
+ geom_point(aes(displ, hwy, color = class)) +
  scale_colour_r2dii_tech("automotive")
 
- ggplot(data = mpg) +
- geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5) +
+ ggplot(mpg) +
+ geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
  scale_fill_r2dii_tech("automotive")
 }

--- a/tests/testthat/test-scale_r2dii.R
+++ b/tests/testthat/test-scale_r2dii.R
@@ -11,8 +11,8 @@ test_that("if with bad `labels` errors gracefully", {
 })
 
 test_that("changes the plot colours as expected", {
-  p <- ggplot(data = ggplot2::mpg) +
-    geom_point(mapping = aes(x = displ, y = hwy, colour = class))
+  p <- ggplot(ggplot2::mpg) +
+    geom_point(aes(displ, hwy, colour = class))
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["colour"])
 
@@ -24,8 +24,8 @@ test_that("changes the plot colours as expected", {
 })
 
 test_that("changes the plot fill as expected", {
-  p <- ggplot(data = ggplot2::mpg) +
-    geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5)
+  p <- ggplot(ggplot2::mpg) +
+    geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5)
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["fill"])
 

--- a/tests/testthat/test-scale_r2dii.R
+++ b/tests/testthat/test-scale_r2dii.R
@@ -11,7 +11,7 @@ test_that("if with bad `labels` errors gracefully", {
 })
 
 test_that("changes the plot colours as expected", {
-  p <- ggplot(ggplot2::mpg) +
+  p <- ggplot(mpg) +
     geom_point(aes(displ, hwy, colour = class))
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["colour"])
@@ -24,7 +24,7 @@ test_that("changes the plot colours as expected", {
 })
 
 test_that("changes the plot fill as expected", {
-  p <- ggplot(ggplot2::mpg) +
+  p <- ggplot(mpg) +
     geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5)
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["fill"])

--- a/tests/testthat/test-scale_r2dii_sector.R
+++ b/tests/testthat/test-scale_r2dii_sector.R
@@ -11,8 +11,8 @@ test_that("if with bad `sectors` errors gracefully", {
 })
 
 test_that("changes the plot colours as expected", {
-  p <- ggplot(data = ggplot2::mpg) +
-    geom_point(mapping = aes(x = displ, y = hwy, colour = class))
+  p <- ggplot(ggplot2::mpg) +
+    geom_point(aes(displ, hwy, colour = class))
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["colour"])
 
@@ -24,8 +24,8 @@ test_that("changes the plot colours as expected", {
 })
 
 test_that("changes the plot fill as expected", {
-  p <- ggplot(data = ggplot2::mpg) +
-    geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5)
+  p <- ggplot(ggplot2::mpg) +
+    geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5)
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["fill"])
 

--- a/tests/testthat/test-scale_r2dii_sector.R
+++ b/tests/testthat/test-scale_r2dii_sector.R
@@ -11,7 +11,7 @@ test_that("if with bad `sectors` errors gracefully", {
 })
 
 test_that("changes the plot colours as expected", {
-  p <- ggplot(ggplot2::mpg) +
+  p <- ggplot(mpg) +
     geom_point(aes(displ, hwy, colour = class))
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["colour"])
@@ -24,7 +24,7 @@ test_that("changes the plot colours as expected", {
 })
 
 test_that("changes the plot fill as expected", {
-  p <- ggplot(ggplot2::mpg) +
+  p <- ggplot(mpg) +
     geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5)
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["fill"])

--- a/tests/testthat/test-scale_r2dii_tech.R
+++ b/tests/testthat/test-scale_r2dii_tech.R
@@ -17,7 +17,7 @@ test_that("if with bad `technologies` errors gracefully", {
 })
 
 test_that("changes the plot colours as expected", {
-  p <- ggplot(ggplot2::mpg) +
+  p <- ggplot(mpg) +
     geom_point(aes(displ, hwy, colour = class))
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["colour"])
@@ -30,7 +30,7 @@ test_that("changes the plot colours as expected", {
 })
 
 test_that("changes the plot fill as expected", {
-  p <- ggplot(ggplot2::mpg) +
+  p <- ggplot(mpg) +
     geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5)
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["fill"])

--- a/tests/testthat/test-scale_r2dii_tech.R
+++ b/tests/testthat/test-scale_r2dii_tech.R
@@ -17,8 +17,8 @@ test_that("if with bad `technologies` errors gracefully", {
 })
 
 test_that("changes the plot colours as expected", {
-  p <- ggplot(data = ggplot2::mpg) +
-    geom_point(mapping = aes(x = displ, y = hwy, colour = class))
+  p <- ggplot(ggplot2::mpg) +
+    geom_point(aes(displ, hwy, colour = class))
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["colour"])
 
@@ -30,8 +30,8 @@ test_that("changes the plot colours as expected", {
 })
 
 test_that("changes the plot fill as expected", {
-  p <- ggplot(data = ggplot2::mpg) +
-    geom_histogram(mapping = aes(x = cyl, fill = class), position = "dodge", bins = 5)
+  p <- ggplot(ggplot2::mpg) +
+    geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5)
   g <- ggplot_build(p)
   colours_default <- unique(g$data[[1]]["fill"])
 

--- a/vignettes/r2dii-plot.Rmd
+++ b/vignettes/r2dii-plot.Rmd
@@ -221,7 +221,7 @@ data <- market_share %>%
     year %in% c(2020, 2025)
   )
 
-ggplot(data, aes(x = factor(year), y = production)) +
+ggplot(data, aes(factor(year), production)) +
   geom_col() +
   facet_wrap(~technology) +
   theme_2dii()
@@ -241,7 +241,7 @@ data <- market_share %>%
     technology == "renewablescap"
   )
 
-ggplot(data, aes(x = year, y = production, color = metric)) +
+ggplot(data, aes(year, production, color = metric)) +
   geom_line() +
   scale_colour_r2dii(labels = c("dark_blue", "green", "orange", "ruby_red")) +
   theme_2dii()
@@ -261,7 +261,7 @@ data <- market_share %>%
   group_by(sector, year) %>%
   summarise(production = sum(production))
 
-ggplot(data, aes(x = factor(year), y = production, fill = sector)) +
+ggplot(data, aes(factor(year), production, fill = sector)) +
   geom_col() +
   scale_fill_r2dii_sector(sectors = c("automotive", "oil&gas", "power")) +
   theme_2dii() +
@@ -288,7 +288,7 @@ data <- market_share %>%
   ) %>%
   arrange(technology)
 
-ggplot(data, aes(x = factor(year), y = production, fill = technology)) +
+ggplot(data, aes(factor(year), production, fill = technology)) +
   geom_col() +
   scale_fill_r2dii_tech("power", technologies = c("coalcap", "oilcap", "gascap", "hydrocap", "renewablescap")) +
   facet_wrap(~technology) +


### PR DESCRIPTION
- Remove commonly ommited arguments (first and maybe second)
- Remove namespace in functions already imported in R/imports.R

This won't affect the robustness of the code and adds clutter 
that obscures the structure of the code. Each tiny thing seems
minor but the clutter adds up fast. 

Compare:
  
  # Intentionally cluttered to make my point
  ggplot2::ggplot(data = ggplot2::mpg) + 
    geom_point(mappings = ggplot2::aes(x = cyl, y = displ)
  
  # Decluttered
  ggplot(mpg) + 
    geom_point(aes(cyl, displ)
