### PR TITLE
Fix bug trajectory

### DIFF
--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -148,6 +148,7 @@ plot_trajectory_impl <- function(data) {
 
   p +
     coord_cartesian(expand = FALSE, clip = "off") +
+    scale_x_continuous(breaks = integer_breaks()) +
     scale_fill_manual(values = scenario_colour(data)$colour) +
     # Calling `scale_fill_manual()` twice is intentional (https://git.io/JnDPc)
     scale_fill_manual(aesthetics = "segment.color", values = line_colours(data)) +

--- a/R/utils.R
+++ b/R/utils.R
@@ -318,3 +318,13 @@ r2dii_pal_impl <- function(x, data, column) {
   attr(f, "max_n") <- max_n
   f
 }
+
+# source: https://joshuacook.netlify.app/post/integer-values-ggplot-axis/
+integer_breaks <- function(n = 5, ...) {
+  fxn <- function(x) {
+    breaks <- floor(pretty(x, n, ...))
+    names(breaks) <- attr(breaks, "labels")
+    breaks
+  }
+  return(fxn)
+}

--- a/tests/testthat/test-plot_trajectory.R
+++ b/tests/testthat/test-plot_trajectory.R
@@ -77,3 +77,20 @@ test_that("Is sensitive to `center_y`", {
 
   expect_true(abs(start_val - lower_y_limit_centered) == abs(start_val - upper_y_limit_centered))
 })
+
+test_that("Doesn't output plots with non-integer x-axis tick marks", {
+  data <- market_share %>%
+    filter(
+      sector == "power",
+      technology == "renewablescap",
+      region == "global",
+      scenario_source == "demo_2020",
+      between(year, 2020, 2030)
+    )
+
+  p <- plot_trajectory(data)
+  g <- ggplot_build(p)
+  x_axis_breaks <- g$layout$panel_params[[1]]$x$minor_breaks
+
+  expect_true(all(x_axis_breaks - floor(x_axis_breaks) == 0))
+})


### PR DESCRIPTION
Closes #403 

In this PR I fix the bug causing the x-axis to have non-integer tick-marks.

Note: it might also have been fixed by converting the years in data to date format but I didn't want to go at the moment through all the implications of this change. This is a quick fix. We might want to align with `plot_emission_intensity()` at some point (which uses dates).

Reprex of a fix (same data as in issue #403 ):

``` r
devtools::load_all()
#> ℹ Loading r2dii.plot
library(dplyr, warn.conflicts = FALSE)

data <- market_share %>%
  filter(
    sector == "power",
    technology == "renewablescap",
    region == "global",
    scenario_source == "demo_2020",
    between(year, 2020, 2030)
  )

plot_trajectory(data)
#> Normalizing `production` values to 2020 -- the start year.
```

![](https://i.imgur.com/QgdokXh.png)

<sup>Created on 2021-10-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>