### PR TITLE
Make cran-comments.md easier to maintain

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Test environments
 
-* ubuntu 18.04 (local), R 4.1.0
+* ubuntu 18.04 (local), R-release
 * ubuntu 18.04 (github actions), R-oldrel, R-release, R-devel
 * macOS-latest (github actions), R-release
 * windows-latest (github actions), R-oldrel, R-release


### PR DESCRIPTION
This is less specific so we don't need to edit it so often -- e.g.
when there is a new R release.

In r-lib/ I see some packages don't even include the most brittle
section -- the one that reports the check environments.
