### PR TITLE
process only unique strings for speed improvement

### DIFF
--- a/R/to_title.R
+++ b/R/to_title.R
@@ -27,7 +27,9 @@ to_title <- function(x) {
     paste(words, collapse = " ")
   }
 
-  unlist(lapply(x, to_title_one))
+  x_fctr <- factor(x)
+  levels(x_fctr) <- sapply(levels(x_fctr), to_title_one)
+  as.character(x_fctr)
 }
 
 capitalize_single_letters <- function(words) {


### PR DESCRIPTION
this supersedes #453 because that was based on master

The current version of `to_title()` in the develop branch cleans up strings in a vector, but if the vector contains many duplicates of one or many strings, it will do the same thing for every element of the vector potentially multiplying the needed effort. This PR first converts the vector to a factor, then process only the levels of that factor (which are by definition unique), then coerces the full factor vector back to character. On small vectors, this won't make much of a difference, but in large vectors with a lot of duplication (e.g. [here](https://github.com/2DegreesInvesting/plots.impact/blob/master/main_analysis.R#L9-L23)), this can easily improve the speed by multiples.

```r
library(microbenchmark)
devtools::load_all()

to_title_fast <- function(x) {
  to_title_one <- function(x) {
    words <- tolower(unlist(strsplit(x, "[^[:alnum:]]+")))
    # `toTitleCase()` with "a" returns "a", not "A" (a bug in this context)
    words <- capitalize_single_letters(tools::toTitleCase(words))
    paste(words, collapse = " ")
  }
  
  x_fctr <- factor(x)
  levels(x_fctr) <- sapply(levels(x_fctr), to_title_one)
  as.character(x_fctr)
}

strings <- c("a.string", "another_STRING")
strings_10 <- rep(strings, 10)
strings_100 <- rep(strings, 100)

to_title(strings)
#> [1] "A String"       "Another String"
to_title_fast(strings)
#> [1] "A String"       "Another String"

microbenchmark(
  to_title(strings),
  to_title_fast(strings), 
  to_title(strings_10),
  to_title_fast(strings_10),
  to_title(strings_100),
  to_title_fast(strings_100)
)

#> Unit: microseconds
#>                        expr       min         lq       mean     median         uq       max neval
#>           to_title(strings)   363.916   371.3985   379.0803   374.4120   379.4960   573.631   100
#>      to_title_fast(strings)   391.632   398.7865   440.0194   411.9065   434.4565  2445.363   100
#>        to_title(strings_10)  3640.390  3702.6895  3821.8117  3740.9835  3798.5885  5759.967   100
#>   to_title_fast(strings_10)   391.345   399.1145   416.7027   409.0980   430.6845   491.672   100
#>       to_title(strings_100) 36608.572 37396.1205 38201.6090 37772.2340 39072.9795 42922.244   100
#>  to_title_fast(strings_100)   395.978   403.5015   448.4387   414.8380   439.3355  3133.343   100
```