### PR TITLE
Add action checking compatibility with development versions of r2dii

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -56,15 +56,3 @@ jobs:
           extra-packages: rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v1
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -6,9 +6,9 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
+    branches: [develop, main, master]
   pull_request:
-    branches: [main, master]
+    branches: [develop, main, master]
 
 name: R-CMD-check
 

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -6,9 +6,9 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [develop, main, master]
+    branches: [main, master]
   pull_request:
-    branches: [develop, main, master]
+    branches: [main, master]
 
 name: R-CMD-check
 

--- a/.github/workflows/check-full_r2dii-devel.yaml
+++ b/.github/workflows/check-full_r2dii-devel.yaml
@@ -63,15 +63,3 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v1
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check

--- a/.github/workflows/check-full_r2dii-devel.yaml
+++ b/.github/workflows/check-full_r2dii-devel.yaml
@@ -1,0 +1,77 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow is overkill for most R packages and
+# check-standard.yaml is likely a better choice.
+# usethis::use_github_action("check-standard") will install it.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check r2dii-devel
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+
+          - {os: windows-latest, r: 'release'}
+          # Use 3.6 to trigger usage of RTools35
+          - {os: windows-latest, r: '3.6'}
+
+          # Use older ubuntu to maximise backward compatibility
+          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-18.04,   r: 'release'}
+          - {os: ubuntu-18.04,   r: 'oldrel-1'}
+          - {os: ubuntu-18.04,   r: 'oldrel-2'}
+          - {os: ubuntu-18.04,   r: 'oldrel-3'}
+          - {os: ubuntu-18.04,   r: 'oldrel-4'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: rcmdcheck
+
+      - name: Install devel version of other r2dii packages
+        run: |
+          pak::pkg_install("2DegreesInvesting/r2dii.data")
+          pak::pkg_install("2DegreesInvesting/r2dii.match")
+          pak::pkg_install("2DegreesInvesting/r2dii.analysis")
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v1
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/.github/workflows/check-full_r2dii-devel.yaml
+++ b/.github/workflows/check-full_r2dii-devel.yaml
@@ -29,12 +29,7 @@ jobs:
           - {os: windows-latest, r: '3.6'}
 
           # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-full_r2dii-devel.yaml
+++ b/.github/workflows/check-full_r2dii-devel.yaml
@@ -6,9 +6,9 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
+    branches: [develop, main, master]
   pull_request:
-    branches: [main, master]
+    branches: [develop, main, master]
 
 name: R-CMD-check r2dii-devel
 


### PR DESCRIPTION
In this PR I add a GitHub action to check if the package works with devel versions of other `r2dii` packages.

I based it on GH action from `r2dii.analysis` package: https://github.com/2DegreesInvesting/r2dii.analysis/blob/main/.github/workflows/check-full_r2dii-devel.yaml