### PR TITLE
Fix sda test

### DIFF
--- a/tests/testthat/test-sda.R
+++ b/tests/testthat/test-sda.R
@@ -17,8 +17,8 @@ test_that("outputs like r2dii.analysis::target_sda()", {
   sort_df <- function(data) data[sort(names(data))]
 
   # Pick small data for speed. "package::f()" is to emphasize integration
-  loanbook <- r2dii.data::loanbook_demo[125:150, ]
-  ald <- filter(r2dii.data::ald_demo[1:100, ], !is.na(.data$emission_factor))
+  loanbook <- r2dii.data::loanbook_demo
+  ald <- filter(r2dii.data::ald_demo, !is.na(.data$emission_factor))
   scenario <- r2dii.data::co2_intensity_scenario_demo
   region_isos <- r2dii.data::region_isos_demo
 


### PR DESCRIPTION
There was a change in develop version of `r2dii.analysis` ([PR #403](https://github.com/2DegreesInvesting/r2dii.analysis/pull/403)) which caused our intergration test for sda demo dataset to fail. This PR fixes it.